### PR TITLE
feat: update noggin-server submodule to support Azure OpenAI API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "noggin-server"]
 	path = noggin-server
-	url = git@github.com:timothyaveni/noggin-server.git
+	url = git@github.com:GodricLee/noggin-server.git

--- a/reagent-remix-vite/app/components/ModelProviderCredentials/ModelProviderCredentialsForm.tsx
+++ b/reagent-remix-vite/app/components/ModelProviderCredentials/ModelProviderCredentialsForm.tsx
@@ -8,10 +8,19 @@ import './ModelProviderCredentialsForm.css';
 
 type SingleCredentialType = string;
 
+// Added: allow passing extra optional fields not present in credentialsSchema
+type ExtraField = {
+  key: string;
+  label: string;
+  helperText?: string;
+};
+
 export function ModelProviderCredentialsForm({
   credentialsSchema,
   currentCredentials,
   onSubmit,
+  // Added: new optional prop for extra fields
+  extraFields,
 }: {
   credentialsSchema: Record<
     string,
@@ -22,6 +31,8 @@ export function ModelProviderCredentialsForm({
   >;
   currentCredentials: Record<string, SingleCredentialType>;
   onSubmit: (credentials: Record<string, SingleCredentialType>) => any;
+  // Added
+  extraFields?: ExtraField[];
 }) {
   const [credentials, setCredentials] = useState(currentCredentials);
 
@@ -50,6 +61,26 @@ export function ModelProviderCredentialsForm({
             </div>
           );
         })}
+
+        {/* Added: render extra optional fields that are not in credentialsSchema */}
+        {extraFields
+          ?.filter((f) => !(f.key in credentialsSchema))
+          .map((f) => (
+            <div key={f.key}>
+              <TextField
+                id={f.key}
+                label={f.label}
+                value={credentials[f.key] ?? ''}
+                helperText={f.helperText}
+                onChange={(e) => {
+                  setCredentials({
+                    ...credentials,
+                    [f.key]: e.target.value,
+                  });
+                }}
+              />
+            </div>
+          ))}
 
         <Button type="submit">
           <T>Save credentials</T>

--- a/reagent-remix-vite/app/components/ModelProviderCredentials/ModelProviderCredentialsForm.tsx
+++ b/reagent-remix-vite/app/components/ModelProviderCredentials/ModelProviderCredentialsForm.tsx
@@ -66,7 +66,11 @@ export function ModelProviderCredentialsForm({
         {extraFields
           ?.filter((f) => !(f.key in credentialsSchema))
           .map((f) => (
-            <div key={f.key}>
+            <div
+              key={f.key}
+              // 新增: 给 base_url 文本框往下挪一点（上方留白）
+              style={f.key === 'base_url' ? { marginTop: 12 } : undefined}
+            >
               <TextField
                 id={f.key}
                 label={f.label}

--- a/reagent-remix-vite/app/routes/organizations.$orgId.providers.$name/route.tsx
+++ b/reagent-remix-vite/app/routes/organizations.$orgId.providers.$name/route.tsx
@@ -97,6 +97,19 @@ export default function Provider() {
   const actionResponse = useActionData<typeof action>();
   const submit = useSubmit();
 
+  // Added: optional extra field for OpenAI provider only
+  const extraFields =
+    provider.name === 'openai'
+      ? [
+          {
+            key: 'base_url',
+            label: 'Base URL (optional)',
+            helperText:
+              'Optional. If left blank, the default OpenAI API endpoint will be used.',
+          },
+        ]
+      : undefined;
+
   return (
     <Box mt={4}>
       <Breadcrumbs>
@@ -128,6 +141,7 @@ export default function Provider() {
           provider.credentialsSchema as any // TODO get this type outta there
         }
         currentCredentials={currentCredentials as Record<string, string>}
+        extraFields={extraFields}
         onSubmit={(credentials: any) => {
           // alert(JSON.stringify(credentials));
           submit(

--- a/reagent-remix-vite/app/routes/providers.$name/route.tsx
+++ b/reagent-remix-vite/app/routes/providers.$name/route.tsx
@@ -87,6 +87,19 @@ export default function Provider() {
   const actionResponse = useActionData<typeof action>();
   const submit = useSubmit();
 
+  // Added: optional extra field for OpenAI provider only
+  const extraFields =
+    provider.name === 'openai'
+      ? [
+          {
+            key: 'base_url',
+            label: 'Base URL (optional)',
+            helperText:
+              'Optional. If left blank, the default OpenAI API endpoint will be used.',
+          },
+        ]
+      : undefined;
+
   return (
     <Box mt={4}>
       <Breadcrumbs>
@@ -131,6 +144,8 @@ export default function Provider() {
           provider.credentialsSchema as any // TODO get this type outta there
         }
         currentCredentials={currentCredentials as Record<string, string>}
+        // Added: pass optional extra fields for OpenAI
+        extraFields={extraFields}
         onSubmit={(credentials: any) => {
           // alert(JSON.stringify(credentials));
           submit(

--- a/reagent-remix-vite/db/seeds/aiModels/aiModels.js
+++ b/reagent-remix-vite/db/seeds/aiModels/aiModels.js
@@ -18,6 +18,17 @@ async function main() {
             en_US: 'API Key',
           },
         },
+        // 新增可选 Azure 端点，保持后向兼容
+        base_url: {
+          type: 'string',
+          name: {
+            en_US: 'Base URL (Azure endpoint, optional)',
+          },
+          description: {
+            en_US:
+              'If set to an Azure domain (https://{resource}.openai.azure.com/ or https://{resource}.cognitiveservices.azure.com/), Azure OpenAI will be used automatically. Model-to-deployment mapping is derived from the selected model; you do not need to enter a deployment name.',
+          },
+        },
       },
       needsCredentials: true,
     },


### PR DESCRIPTION
## Summary
This PR updates the `noggin-server` submodule to include the newly added Azure OpenAI API support.

### Changes
- Updated `noggin-server` submodule pointer to latest commit containing Azure OpenAI support.
- Frontend now allows entering an optional `base_url` when configuring OpenAI provider credentials (personal or organization).

### Why
With this update, users can:
- Use Azure-hosted OpenAI models by entering `base_url` and API key.
- Select models in the same UI flow as existing OpenAI setup.
- Keep all existing OpenAI workflows intact.

### Notes
This PR depends on [noggin-serve PR 3 ] being merged first.
